### PR TITLE
Change from naming which conflicts with Mailable class

### DIFF
--- a/src/ExceptionMailer.php
+++ b/src/ExceptionMailer.php
@@ -26,24 +26,19 @@ class ExceptionMailer extends Mailable implements ShouldQueue
     public $body;
 
     /**
-     * Sender's address.
-     *
-     * @var string
-     */
-    public $customFrom;
-
-    /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($subject, $body, $from)
+    public function __construct($subject, $body, $from = null)
     {
         $this->subject = $subject;
 
         $this->body = $body;
 
-        $this->customFrom = $from;
+        if($from) {
+            $this->from($from);
+        }
     }
 
     /**
@@ -53,10 +48,6 @@ class ExceptionMailer extends Mailable implements ShouldQueue
      */
     public function build()
     {
-        if($this->customFrom) {
-            $this->from($this->customFrom);
-        }
-
         return $this->view('sneaker::raw')
                     ->with('content', $this->body);
     }

--- a/src/ExceptionMailer.php
+++ b/src/ExceptionMailer.php
@@ -30,7 +30,7 @@ class ExceptionMailer extends Mailable implements ShouldQueue
      *
      * @var string
      */
-    public $from;
+    public $customFrom;
 
     /**
      * Create a new message instance.
@@ -43,7 +43,7 @@ class ExceptionMailer extends Mailable implements ShouldQueue
 
         $this->body = $body;
 
-        $this->from = $from;
+        $this->customFrom = $from;
     }
 
     /**
@@ -53,8 +53,8 @@ class ExceptionMailer extends Mailable implements ShouldQueue
      */
     public function build()
     {
-        if($this->from) {
-            $this->from($this->from);
+        if($this->customFrom) {
+            $this->from($this->customFrom);
         }
 
         return $this->view('sneaker::raw')


### PR DESCRIPTION
Fix errors like:
`Symfony\Component\Debug\Exception\FatalThrowableError: [] operator not supported for strings in \vendor\laravel\framework\src\Illuminate\Mail\Mailable.php:460`